### PR TITLE
Add MacAudioInput app to manage light based on audio state

### DIFF
--- a/NetDaemonApps/DomainEntities/HaCommonState.cs
+++ b/NetDaemonApps/DomainEntities/HaCommonState.cs
@@ -1,0 +1,17 @@
+namespace NetDaemonApps.DomainEntities;
+
+public class HaCommonState
+{
+    public static readonly HaCommonState Active = new("Active");
+    
+    public static readonly HaCommonState InActive = new("Inactive");
+    
+    private string Value { get; }
+
+    private HaCommonState(string value)
+    {
+        Value = value;
+    }
+
+    public override string ToString() => Value;
+}

--- a/NetDaemonApps/apps/ShawnRoom/MacAudioInput.cs
+++ b/NetDaemonApps/apps/ShawnRoom/MacAudioInput.cs
@@ -1,0 +1,58 @@
+using NetDaemon.HassModel.Entities;
+
+namespace NetDaemonApps.apps.ShawnRoom;
+
+[NetDaemonApp(Id = $"{nameof(ShawnRoom)}_{nameof(MacAudioInput)}")]
+public class MacAudioInput
+{
+    private readonly Entities _entities;
+    private readonly ILogger _logger;
+
+    public MacAudioInput(Entities entities, ILogger<MacAudioInput> logger)
+    {
+        _entities = entities;
+        _logger = logger;
+
+        entities.Sensor.ShawnsMacbookProActiveAudioInput
+            .StateChanges()
+            .Subscribe(s => ProcessState(s));
+    }
+
+    private LightAttributes? LastKnownLightAttributes { get; set; }
+
+    private void ProcessState(StateChange<SensorEntity, EntityState<SensorAttributes>> stateChange)
+    {
+        var newState = stateChange.New?.State;
+        var oldState = stateChange.Old?.State;
+        
+        _logger.LogInformation("State changed from {oldState} to {newState}", oldState, newState);
+        
+        if (newState == HaCommonState.Active.ToString())
+        {
+            HandleActiveState();
+        }
+        else if (newState == HaCommonState.InActive.ToString())
+        {
+            HandleInactiveState();
+        }
+    }
+
+    private void HandleActiveState()
+    {
+        LastKnownLightAttributes = _entities.Light.HuePlayRight.Attributes;
+        _entities.Light.HuePlayRight.TurnOn(colorName: "Red");
+    }
+
+    private void HandleInactiveState()
+    {
+        if (LastKnownLightAttributes == null)
+        {
+            _logger.LogWarning("The last known light attributes did not save. Turning light off instead.");
+            _entities.Light.HuePlayRight.TurnOff();
+        }
+        else
+        {
+            _entities.Light.HuePlayRight.TurnOn(hsColor: LastKnownLightAttributes.HsColor);
+        }
+    }
+}

--- a/NetDaemonApps/appsettings.json
+++ b/NetDaemonApps/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
     "Logging": {
         "LogLevel": {
-            "Default": "Debug",
+            "Default": "Information",
             "Microsoft": "Warning"
         },
         "ConsoleThemeType": "Ansi"


### PR DESCRIPTION
Introduced a new app `MacAudioInput` to handle state changes in MacBook's audio input and control the HuePlayRight light accordingly. Added a `HaCommonState` helper class for consistent state representation. Adjusted logging level in `appsettings.json` from Debug to Information for cleaner log output.