### PR TITLE
Refactor namespaces and refine MqttEntities imports

### DIFF
--- a/MqttEntities/BedRoom/BedroomRoomStateSelect.cs
+++ b/MqttEntities/BedRoom/BedroomRoomStateSelect.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Domain.Entities;
+using MqttEntities.Common;
 
 namespace MqttEntities.BedRoom;
 

--- a/MqttEntities/Common/MqttButton.cs
+++ b/MqttEntities/Common/MqttButton.cs
@@ -1,4 +1,6 @@
-namespace Domain.Entities;
+using Domain.Entities;
+
+namespace MqttEntities.Common;
 
 public abstract class MqttButton(string groupName, string entityName, string displayName)
     : MqttEntity(HaEntityType.Button, groupName, entityName, displayName);

--- a/MqttEntities/Common/MqttCover.cs
+++ b/MqttEntities/Common/MqttCover.cs
@@ -1,4 +1,6 @@
-namespace Domain.Entities;
+using Domain.Entities;
+
+namespace MqttEntities.Common;
 
 public abstract class MqttCover(string groupName, string entityName, string displayName)
     : MqttEntity(HaEntityType.Cover, groupName, entityName, displayName);

--- a/MqttEntities/Common/MqttEntity.cs
+++ b/MqttEntities/Common/MqttEntity.cs
@@ -1,6 +1,8 @@
 
 
-namespace Domain.Entities;
+using Domain.Entities;
+
+namespace MqttEntities.Common;
 
 public abstract class MqttEntity(HaEntityType entityType, string groupName, string entityName, string displayName)
 {

--- a/MqttEntities/Common/MqttEntityManager.cs
+++ b/MqttEntities/Common/MqttEntityManager.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
 
-namespace Domain.Entities;
+namespace MqttEntities.Common;
 
 public class MqttEntityManager
 {

--- a/MqttEntities/Common/MqttSelect.cs
+++ b/MqttEntities/Common/MqttSelect.cs
@@ -1,6 +1,8 @@
 
 
-namespace Domain.Entities;
+using Domain.Entities;
+
+namespace MqttEntities.Common;
 
 /// <summary>
 /// Represents an MQTT-based select component in a Home Automation context.

--- a/MqttEntities/Common/MqttSensor.cs
+++ b/MqttEntities/Common/MqttSensor.cs
@@ -1,6 +1,8 @@
 
 
-namespace Domain.Entities;
+using Domain.Entities;
+
+namespace MqttEntities.Common;
 
 public abstract class MqttSensor(string groupName, string entityName, string displayName)
     : MqttEntity(HaEntityType.Sensor, groupName, entityName, displayName)

--- a/MqttEntities/Common/MqttSwitch.cs
+++ b/MqttEntities/Common/MqttSwitch.cs
@@ -1,6 +1,8 @@
 
 
-namespace Domain.Entities;
+using Domain.Entities;
+
+namespace MqttEntities.Common;
 
 /// <summary>
 /// Represents an abstract MQTT switch that can handle state changes and provides

--- a/MqttEntities/House/CameraNotificationsSwitch.cs
+++ b/MqttEntities/House/CameraNotificationsSwitch.cs
@@ -1,4 +1,5 @@
 using Domain.Entities;
+using MqttEntities.Common;
 
 namespace MqttEntities.House;
 

--- a/MqttEntities/House/GarageDoor.cs
+++ b/MqttEntities/House/GarageDoor.cs
@@ -1,4 +1,5 @@
 using Domain.Entities;
+using MqttEntities.Common;
 
 namespace MqttEntities.House;
 

--- a/MqttEntities/House/HouseStateSelect.cs
+++ b/MqttEntities/House/HouseStateSelect.cs
@@ -1,4 +1,5 @@
 using Domain.Entities;
+using MqttEntities.Common;
 
 namespace MqttEntities.House;
 

--- a/MqttEntities/House/WaterLeakDetectedSwitch.cs
+++ b/MqttEntities/House/WaterLeakDetectedSwitch.cs
@@ -1,4 +1,5 @@
 using Domain.Entities;
+using MqttEntities.Common;
 
 namespace MqttEntities.House;
 

--- a/MqttEntities/JustinsRoom/JustinsRoomStateSelect.cs
+++ b/MqttEntities/JustinsRoom/JustinsRoomStateSelect.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Domain.Entities;
+using MqttEntities.Common;
 
 namespace MqttEntities.JustinsRoom;
 

--- a/MqttEntities/MainRoom/MainRoomStateSelect.cs
+++ b/MqttEntities/MainRoom/MainRoomStateSelect.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Domain.Entities;
+using MqttEntities.Common;
 
 namespace MqttEntities.MainRoom;
 

--- a/MqttEntities/MainRoom/MainRoomStateSwitch.cs
+++ b/MqttEntities/MainRoom/MainRoomStateSwitch.cs
@@ -1,4 +1,5 @@
 using Domain.Entities;
+using MqttEntities.Common;
 
 namespace MqttEntities.MainRoom;
 

--- a/MqttEntities/Program.cs
+++ b/MqttEntities/Program.cs
@@ -3,6 +3,7 @@ using Domain.Entities;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using MqttEntities.Common;
 using NetDaemon.Extensions.MqttEntityManager;
 
 var host = Host.CreateDefaultBuilder()

--- a/MqttEntities/ShawnsRoom/DndSwitch.cs
+++ b/MqttEntities/ShawnsRoom/DndSwitch.cs
@@ -1,4 +1,5 @@
 using Domain.Entities;
+using MqttEntities.Common;
 
 namespace MqttEntities.ShawnsRoom;
 

--- a/MqttEntities/ShawnsRoom/ShawnsRoomStateSelect.cs
+++ b/MqttEntities/ShawnsRoom/ShawnsRoomStateSelect.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Domain.Entities;
+using MqttEntities.Common;
 
 namespace MqttEntities.ShawnsRoom;
 

--- a/MqttEntities/ShawnsRoom/ShawnsRoomStateSwitch.cs
+++ b/MqttEntities/ShawnsRoom/ShawnsRoomStateSwitch.cs
@@ -1,4 +1,5 @@
 using Domain.Entities;
+using MqttEntities.Common;
 
 namespace MqttEntities.ShawnsRoom;
 

--- a/NetDaemonApps/apps/House/Cameras.cs
+++ b/NetDaemonApps/apps/House/Cameras.cs
@@ -2,7 +2,7 @@ using System.Reactive.Concurrency;
 using Domain.Entities;
 using NetDaemonApps.Interfaces;
 
-namespace NetDaemonApps.apps.House.Devices;
+namespace NetDaemonApps.apps.House;
 
 [NetDaemonApp]
 public class Cameras

--- a/NetDaemonApps/apps/House/FrontDoorLock.cs
+++ b/NetDaemonApps/apps/House/FrontDoorLock.cs
@@ -1,8 +1,7 @@
 using Domain.Entities;
 using NetDaemonApps.Interfaces;
-using NetDaemonApps.Services;
 
-namespace NetDaemonApps.apps.House.Devices;
+namespace NetDaemonApps.apps.House;
 
 [NetDaemonApp]
 public class FrontDoorLock

--- a/NetDaemonApps/apps/House/GarageDoor.cs
+++ b/NetDaemonApps/apps/House/GarageDoor.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 using Domain.Entities;
 using NetDaemonApps.Interfaces;
 
-namespace NetDaemonApps.apps.House.Devices;
+namespace NetDaemonApps.apps.House;
 
 [NetDaemonApp]
 public class GarageDoor

--- a/NetDaemonApps/apps/House/People.cs
+++ b/NetDaemonApps/apps/House/People.cs
@@ -1,8 +1,7 @@
 using Domain.Entities;
 using NetDaemonApps.Interfaces;
-using NetDaemonApps.Services;
 
-namespace NetDaemonApps.apps.House.Devices;
+namespace NetDaemonApps.apps.House;
 
 [NetDaemonApp]
 public class People

--- a/NetDaemonApps/apps/MqttEntityStateManager.cs
+++ b/NetDaemonApps/apps/MqttEntityStateManager.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Domain.Entities;
 using Microsoft.Extensions.DependencyInjection;
+using MqttEntities.Common;
 using NetDaemon.Extensions.MqttEntityManager;
 using NetDaemon.HassModel.Entities;
 using NetDaemonApps.Interfaces;

--- a/NetDaemonApps/apps/ShawnRoom/DoNotDisturb.cs
+++ b/NetDaemonApps/apps/ShawnRoom/DoNotDisturb.cs
@@ -1,7 +1,6 @@
 using Domain.Entities;
-using NetDaemon.HassModel.Entities;
 
-namespace NetDaemonApps.apps.ShawnRoom.Devices;
+namespace NetDaemonApps.apps.ShawnRoom;
 
 [NetDaemonApp]
 public class DoNotDisturb

--- a/NetDaemonApps/apps/ShawnRoom/MacBookPro.cs
+++ b/NetDaemonApps/apps/ShawnRoom/MacBookPro.cs
@@ -2,7 +2,7 @@ using Domain.Entities;
 using NetDaemon.HassModel.Entities;
 using NetDaemonApps.Interfaces;
 
-namespace NetDaemonApps.apps.ShawnRoom.Devices;
+namespace NetDaemonApps.apps.ShawnRoom;
 
 [NetDaemonApp]
 public class MacBookPro

--- a/NetDaemonApps/apps/ShawnRoom/MotionSensor.cs
+++ b/NetDaemonApps/apps/ShawnRoom/MotionSensor.cs
@@ -1,7 +1,7 @@
 using System.Reactive.Concurrency;
 using NetDaemon.HassModel.Entities;
 
-namespace NetDaemonApps.apps.ShawnRoom.Devices;
+namespace NetDaemonApps.apps.ShawnRoom;
 
 [NetDaemonApp]
 public class MotionSensor

--- a/NetDaemonApps/apps/ShawnRoom/ShawnsRoomState.cs
+++ b/NetDaemonApps/apps/ShawnRoom/ShawnsRoomState.cs
@@ -1,12 +1,9 @@
-
-
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Domain.Entities;
 using NetDaemon.HassModel.Entities;
 using NetDaemonApps.Interfaces;
 
-namespace NetDaemonApps.apps.ShawnRoom.Devices;
+namespace NetDaemonApps.apps.ShawnRoom;
 
 [NetDaemonApp]
 public class ShawnsRoomState


### PR DESCRIPTION
Unified namespaces to align with folder structure and replaced `Domain.Entities` with `MqttEntities.Common` in relevant files. These changes improve maintainability, coherence, and code organization.