### PR TITLE
Fix logic in notification model and update device initialization

### DIFF
--- a/NetDaemonApps/Models/NotifiableDevice.cs
+++ b/NetDaemonApps/Models/NotifiableDevice.cs
@@ -9,6 +9,7 @@ public class NotifiableDevice
     {
         Id = id;
         Name = name;
+        DeviceType = notificationDeviceType;
     }
     
     public string Id { get; init; }

--- a/NetDaemonApps/Models/Notification.cs
+++ b/NetDaemonApps/Models/Notification.cs
@@ -8,13 +8,13 @@ public class Notification
     
     public string? Title { get; init; }
     
+    public bool HasTitle => !string.IsNullOrWhiteSpace(Title);
+    
     public string? Text { get; init; }
+    
+    public bool HasText => !string.IsNullOrWhiteSpace(Text);
     
     public string? Tts { get; init; }
 
-    public bool HasTitle => string.IsNullOrWhiteSpace(Title);
-    
-    public bool HasText => string.IsNullOrWhiteSpace(Text);
-    
-    public bool HasTts => string.IsNullOrWhiteSpace(Tts);
+    public bool HasTts => !string.IsNullOrWhiteSpace(Tts);
 }


### PR DESCRIPTION
Corrected the logic for `HasTitle`, `HasText`, and `HasTts` to properly validate non-empty strings in `Notification`. Additionally, updated `NotifiableDevice` constructor to initialize the `DeviceType` property.