### PR TITLE
Add camera data to notifications and support new device

### DIFF
--- a/NetDaemonApps/Models/NotifiableDevice.cs
+++ b/NetDaemonApps/Models/NotifiableDevice.cs
@@ -5,6 +5,12 @@ namespace NetDaemonApps.Models;
 /// </summary>
 public class NotifiableDevice
 {
+    public enum NotificationDeviceType
+    {
+        Alexa,
+        HomeAssistant
+    }
+    
     public NotifiableDevice(string name, string id, NotificationDeviceType notificationDeviceType)
     {
         Id = id;
@@ -17,10 +23,4 @@ public class NotifiableDevice
     public string Name { get; init; }
     
     public NotificationDeviceType DeviceType { get; init; }
-    
-    public enum NotificationDeviceType
-    {
-        Alexa,
-        HomeAssistant
-    }
 }

--- a/NetDaemonApps/Models/Notification.cs
+++ b/NetDaemonApps/Models/Notification.cs
@@ -17,4 +17,6 @@ public class Notification
     public string? Tts { get; init; }
 
     public bool HasTts => !string.IsNullOrWhiteSpace(Tts);
+    
+    public Camera? Camera { get; init; }
 }

--- a/NetDaemonApps/Services/NotificationService.cs
+++ b/NetDaemonApps/Services/NotificationService.cs
@@ -33,12 +33,18 @@ public class NotificationService(IHaContext ha, IPersonService personService, IL
         "mobile_app_shawns_iphone",
         NotifiableDevice.NotificationDeviceType.HomeAssistant);
     
+    public NotifiableDevice JustinPhone { get; } = new(
+        "Justin's Phone",
+        "mobile_app_husbear",
+        NotifiableDevice.NotificationDeviceType.HomeAssistant);
+    
     public NotifiableDevice[] GetAllDevices =>
     [
         ShawnOfficeAlexa,
         KitchenAlexa,
         ShawnPhone,
         GarageAlexa,
+        JustinPhone
     ];
 
     public void Notify(Notification notification)
@@ -52,7 +58,7 @@ public class NotificationService(IHaContext ha, IPersonService personService, IL
                     break;
                 
                 case NotifiableDevice.NotificationDeviceType.HomeAssistant when notification.HasText:
-                    NotifyHomeAssistantDevice(notifiableDevice, notification.Text, notification.Title);
+                    NotifyHomeAssistantDevice(notifiableDevice, notification.Text, notification.Title, notification.Camera);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -60,18 +66,13 @@ public class NotificationService(IHaContext ha, IPersonService personService, IL
         }
     }
     
-    /// <summary>
-    /// Sends a notification to a specific device using Home Assistant service.
-    /// </summary>
-    /// <param name="notifiableDevice">The device to which the notification is sent.</param>
-    /// <param name="message">The message content of the notification. Optional.</param>
-    /// <param name="title">The title of the notification. Optional.</param>
-    private void NotifyHomeAssistantDevice(NotifiableDevice notifiableDevice, string? message, string? title)
+    private void NotifyHomeAssistantDevice(NotifiableDevice notifiableDevice, string? message, string? title, Camera? camera)
     {
         var data = new
         {
             message,
-            title
+            title,
+            data = new { entity_id = camera?.CameraEntity.EntityId }
         };
         
         ha.CallService(HaDomain, notifiableDevice.Id, data: data);

--- a/NetDaemonApps/apps/House/Cameras.cs
+++ b/NetDaemonApps/apps/House/Cameras.cs
@@ -34,7 +34,7 @@ public class Cameras
                 .Where(w => w.New?.State == HaState.On)
                 .Subscribe(_ =>
                 {
-                    Notify($"💁🏻‍♂️📸 {camera.Name} camera has detected a person", $"{camera.Name} camera has detected a person.");
+                    Notify($"💁🏻‍♂️📸 {camera.Name} camera has detected a person", $"{camera.Name} camera has detected a person.", camera);
                 });
         }
         
@@ -45,7 +45,7 @@ public class Cameras
                 .Where(w => w.New?.State == HaState.On)
                 .Subscribe(_ =>
                 {
-                    Notify($"🚙️📸 {camera.Name} camera has detected a vehicle", $"{camera.Name} camera has detected a vehicle.");
+                    Notify($"🚙️📸 {camera.Name} camera has detected a vehicle", $"{camera.Name} camera has detected a vehicle.", camera);
                 });
         }
 
@@ -56,12 +56,12 @@ public class Cameras
                 .Where(w => w.New?.State == HaState.On)
                 .Subscribe(_ =>
                 {
-                    Notify($"🐶📸 {camera.Name} camera has detected an animal", $"{camera.Name} camera has detected an animal.");
+                    Notify($"🐶📸 {camera.Name} camera has detected an animal", $"{camera.Name} camera has detected an animal.", camera);
                 });
         }
     }
 
-    private void Notify(string text, string tts)
+    private void Notify(string text, string tts, Camera camera)
     {
         if (_notificationTimoutEnabled || _switches.HouseCameraNotificationsNetdaemon.State == HaState.Off)
         {
@@ -72,7 +72,8 @@ public class Cameras
         {
             Text = text,
             Tts = tts,
-            Devices = _notificationService.GetAllDevices.ToList()
+            Devices = _notificationService.GetAllDevices.ToList(),
+            Camera = camera
         };
         
         _notificationService.Notify(notification);


### PR DESCRIPTION
Updated the `NotificationService` to include camera data in Home Assistant notifications for enhanced context. Added a new notifiable device, Justin's Phone, and ensured relevant methods and models accommodate the changes.