### PR TITLE
Refactor camera notification handling logic.

### DIFF
--- a/NetDaemonApps/Services/HouseService.cs
+++ b/NetDaemonApps/Services/HouseService.cs
@@ -14,6 +14,7 @@ public class HouseService(
     SelectEntities selects,
     CoverEntities covers,
     ButtonEntities buttons,
+    SwitchEntities switches,
     SunEntities suns) : IHouseService
 {
     public SelectEntity Select => selects.HouseStateNetdaemon;
@@ -68,11 +69,13 @@ public class HouseService(
         buttons.HouseGarageDoorCloseNetdaemon.Press();
         locks.HomeConnect620ConnectedSmartLock.Lock();
         DetermineAndSetOutsideLights();
+        switches.HouseCameraNotificationsNetdaemon.TurnOn();
     }
     
     public void HandleHomeUnsecured()
     {
         DetermineAndSetOutsideLights();
+        switches.HouseCameraNotificationsNetdaemon.TurnOff();
     }
     
     public void HandleAway()
@@ -82,11 +85,13 @@ public class HouseService(
         buttons.HouseGarageDoorCloseNetdaemon.Press();
         locks.HomeConnect620ConnectedSmartLock.Lock();
         DetermineAndSetOutsideLights();
+        switches.HouseCameraNotificationsNetdaemon.TurnOn();
     }
 
     public void HandleSleep()
     {
         shawnRoomService.Switch.TurnOff();
         mainRoomService.Switch.TurnOff();
+        switches.HouseCameraNotificationsNetdaemon.TurnOn();
     }
 }

--- a/NetDaemonApps/apps/House/SilenceCameraNotificationsSwitch.cs
+++ b/NetDaemonApps/apps/House/SilenceCameraNotificationsSwitch.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Concurrency;
+using MqttEntities.Models;
 using NetDaemonApps.Models;
 
 namespace NetDaemonApps.apps.House;
@@ -12,29 +13,28 @@ public class SilenceCameraNotificationsSwitch
     
     private IDisposable? _schedulerSubscription;
     
-    public SilenceCameraNotificationsSwitch(SwitchEntities switches, IScheduler scheduler)
+    public SilenceCameraNotificationsSwitch(SwitchEntities switches, IScheduler scheduler, SelectEntities selects)
     {
         _switches = switches;
         _scheduler = scheduler;
         switches.HouseCameraNotificationsNetdaemon.StateChanges()
             .Where(w => w.New?.State == HaState.On)
-            .Subscribe(_ => HandleOn());
+            .Subscribe(_ => Helpers.CancelSchedule(_schedulerSubscription));
         
         switches.HouseCameraNotificationsNetdaemon.StateChanges()
             .Where(w => w.New?.State == HaState.Off)
-            .Subscribe(_ => HandleOff());
-    }
-    
-    private void HandleOff()
-    {
-        Helpers.CancelSchedule(_schedulerSubscription);
-        _schedulerSubscription = _scheduler.Schedule(
-            TimeSpan.FromMinutes(TurnBackOnInMinutes), 
-            () => _switches.HouseCameraNotificationsNetdaemon.TurnOn());
-    }
-
-    private void HandleOn()
-    {
-        Helpers.CancelSchedule(_schedulerSubscription);
+            .Subscribe(_ =>
+            {
+                Helpers.CancelSchedule(_schedulerSubscription);
+                _schedulerSubscription = _scheduler.Schedule(
+                    TimeSpan.FromMinutes(TurnBackOnInMinutes), 
+                    () =>
+                    {
+                        if (selects.HouseStateNetdaemon.State != RoomStates.HomeUnsecured.ToString())
+                        {
+                            _switches.HouseCameraNotificationsNetdaemon.TurnOn();
+                        }
+                    });
+            });
     }
 }


### PR DESCRIPTION
Update `SilenceCameraNotificationsSwitch` to improve scheduling and add a room state check before turning notifications back on. Enhance `HouseService` to manage camera notifications during specific house states for better automation consistency.