### PR TITLE
Refactor thermostat handling to use extension methods

### DIFF
--- a/NetDaemonApps/Extensions/ClimateEntityExtensions.cs
+++ b/NetDaemonApps/Extensions/ClimateEntityExtensions.cs
@@ -1,0 +1,24 @@
+namespace NetDaemonApps.Extensions;
+
+public static class ClimateEntityExtensions
+{
+    public static void SetNormal(this ClimateEntity climateEntity)
+    {
+        climateEntity.SetTemperature(new ClimateSetTemperatureParameters
+        {
+            TargetTempHigh = 74,
+            TargetTempLow = 72,
+            HvacMode = "heat_cool"
+        });
+    }
+    
+    public static void SetColder(this ClimateEntity climateEntity)
+    {
+        climateEntity.SetTemperature(new ClimateSetTemperatureParameters
+        {
+            TargetTempHigh = 72,
+            TargetTempLow = 70,
+            HvacMode = "heat_cool"
+        });
+    }
+}


### PR DESCRIPTION
Replaced in-line thermostat control logic with dedicated extension methods for cleaner and reusable code. Removed unnecessary IScheduler dependency and simplified the `HouseService` implementation by delegating temperature setting logic to `ClimateEntityExtensions`.