### PR TITLE
Add door event subscribers and corresponding use cases.

### DIFF
--- a/SmartHomeCore.Application/UseCases/DoorClosedUseCase.cs
+++ b/SmartHomeCore.Application/UseCases/DoorClosedUseCase.cs
@@ -1,25 +1,25 @@
 using Microsoft.Extensions.Logging;
 using SmartHomeCore.Application.Common;
+using SmartHomeCore.Domain.DoorEntity;
 using SmartHomeCore.Domain.HouseEntity;
-using SmartHomeCore.Domain.PersonEntity;
 
 namespace SmartHomeCore.Application.UseCases;
 
-public class PersonLeftHomeUseCase(House house, IDomainEventDispatcher domainEventDispatcher, ILogger<PersonLeftHomeUseCase> logger) 
+public class DoorClosedUseCase(House house, IDomainEventDispatcher domainEventDispatcher, ILogger<DoorClosedUseCase> logger)
     : UseCase(house, domainEventDispatcher, logger)
 {
     private readonly House _house = house;
-    private PersonId? PersonId { get; set; }
-
-    public Task HandleAsync(PersonId personId)
+    private DoorId? DoorId { get; set; }
+    
+    public Task HandleAsync(DoorId doorId)
     {
-        PersonId = personId ?? throw new ArgumentNullException(nameof(personId));
+        DoorId = doorId ?? throw new ArgumentNullException(nameof(doorId));
         return base.HandleAsync();
     }
     
     protected override Task ExecuteCoreLogicAsync()
     {
-        _house.MarkPersonAsAway(PersonId!);
+        _house.MarkDoorAsClosed(DoorId!);
         return Task.CompletedTask;
     }
 }

--- a/SmartHomeCore.Application/UseCases/DoorLockedUseCase.cs
+++ b/SmartHomeCore.Application/UseCases/DoorLockedUseCase.cs
@@ -1,25 +1,25 @@
 using Microsoft.Extensions.Logging;
 using SmartHomeCore.Application.Common;
+using SmartHomeCore.Domain.DoorEntity;
 using SmartHomeCore.Domain.HouseEntity;
-using SmartHomeCore.Domain.PersonEntity;
 
 namespace SmartHomeCore.Application.UseCases;
 
-public class PersonLeftHomeUseCase(House house, IDomainEventDispatcher domainEventDispatcher, ILogger<PersonLeftHomeUseCase> logger) 
+public class DoorLockedUseCase(House house, IDomainEventDispatcher domainEventDispatcher, ILogger<DoorLockedUseCase> logger)
     : UseCase(house, domainEventDispatcher, logger)
 {
     private readonly House _house = house;
-    private PersonId? PersonId { get; set; }
-
-    public Task HandleAsync(PersonId personId)
+    private DoorId? DoorId { get; set; }
+    
+    public Task HandleAsync(DoorId doorId)
     {
-        PersonId = personId ?? throw new ArgumentNullException(nameof(personId));
+        DoorId = doorId ?? throw new ArgumentNullException(nameof(doorId));
         return base.HandleAsync();
     }
     
     protected override Task ExecuteCoreLogicAsync()
     {
-        _house.MarkPersonAsAway(PersonId!);
+        _house.MarkDoorAsLocked(DoorId!);
         return Task.CompletedTask;
     }
 }

--- a/SmartHomeCore.Application/UseCases/DoorOpenedUseCase.cs
+++ b/SmartHomeCore.Application/UseCases/DoorOpenedUseCase.cs
@@ -1,25 +1,25 @@
 using Microsoft.Extensions.Logging;
 using SmartHomeCore.Application.Common;
+using SmartHomeCore.Domain.DoorEntity;
 using SmartHomeCore.Domain.HouseEntity;
-using SmartHomeCore.Domain.PersonEntity;
 
 namespace SmartHomeCore.Application.UseCases;
 
-public class PersonLeftHomeUseCase(House house, IDomainEventDispatcher domainEventDispatcher, ILogger<PersonLeftHomeUseCase> logger) 
+public class DoorOpenedUseCase(House house, IDomainEventDispatcher domainEventDispatcher, ILogger<DoorOpenedUseCase> logger)
     : UseCase(house, domainEventDispatcher, logger)
 {
     private readonly House _house = house;
-    private PersonId? PersonId { get; set; }
-
-    public Task HandleAsync(PersonId personId)
+    private DoorId? DoorId { get; set; }
+    
+    public Task HandleAsync(DoorId doorId)
     {
-        PersonId = personId ?? throw new ArgumentNullException(nameof(personId));
+        DoorId = doorId ?? throw new ArgumentNullException(nameof(doorId));
         return base.HandleAsync();
     }
     
     protected override Task ExecuteCoreLogicAsync()
     {
-        _house.MarkPersonAsAway(PersonId!);
+        _house.MarkDoorAsOpen(DoorId!);
         return Task.CompletedTask;
     }
 }

--- a/SmartHomeCore.Application/UseCases/DoorUnLockedUseCase.cs
+++ b/SmartHomeCore.Application/UseCases/DoorUnLockedUseCase.cs
@@ -1,25 +1,25 @@
 using Microsoft.Extensions.Logging;
 using SmartHomeCore.Application.Common;
+using SmartHomeCore.Domain.DoorEntity;
 using SmartHomeCore.Domain.HouseEntity;
-using SmartHomeCore.Domain.PersonEntity;
 
 namespace SmartHomeCore.Application.UseCases;
 
-public class PersonLeftHomeUseCase(House house, IDomainEventDispatcher domainEventDispatcher, ILogger<PersonLeftHomeUseCase> logger) 
+public class DoorUnLockedUseCase(House house, IDomainEventDispatcher domainEventDispatcher, ILogger<DoorUnLockedUseCase> logger)
     : UseCase(house, domainEventDispatcher, logger)
 {
     private readonly House _house = house;
-    private PersonId? PersonId { get; set; }
-
-    public Task HandleAsync(PersonId personId)
+    private DoorId? DoorId { get; set; }
+    
+    public Task HandleAsync(DoorId doorId)
     {
-        PersonId = personId ?? throw new ArgumentNullException(nameof(personId));
+        DoorId = doorId ?? throw new ArgumentNullException(nameof(doorId));
         return base.HandleAsync();
     }
     
     protected override Task ExecuteCoreLogicAsync()
     {
-        _house.MarkPersonAsAway(PersonId!);
+        _house.MarkDoorAsUnlocked(DoorId!);
         return Task.CompletedTask;
     }
 }

--- a/SmartHomeCore.Application/UseCases/PersonArrivedHomeUseCase.cs
+++ b/SmartHomeCore.Application/UseCases/PersonArrivedHomeUseCase.cs
@@ -13,13 +13,13 @@ public class PersonArrivedHomeUseCase(House house, IDomainEventDispatcher domain
 
     public Task HandleAsync(PersonId personId)
     {
-        PersonId = personId;
+        PersonId = personId ?? throw new ArgumentNullException(nameof(personId));
         return base.HandleAsync();
     }
 
     protected override Task ExecuteCoreLogicAsync()
     {
-        _house.MarkPersonAsHome(PersonId ?? throw new NullReferenceException(nameof(PersonId)));
+        _house.MarkPersonAsHome(PersonId!);
         return Task.CompletedTask;
     }
 }

--- a/SmartHomeCore.NetDaemonApps/apps/DoorSubscriber.cs
+++ b/SmartHomeCore.NetDaemonApps/apps/DoorSubscriber.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using NetDaemon.HassModel.Entities;
+using SmartHomeCore.Application.UseCases;
+using SmartHomeCore.Domain.DoorEntity;
+using SmartHomeCore.Domain.HouseEntity;
+using SmartHomeCore.Infrastructure.Integrations.HomeDevices;
+
+namespace SmartHomeCore.NetDaemonApps.apps;
+
+[NetDaemonApp]
+public class DoorSubscriber : SubscriberBase
+{
+    private readonly Predicate<StateChange> _stateChangedToClose = stateChange =>
+        !IsInitialOrFaultyState(stateChange.Old?.State)
+        && stateChange.New?.State.ToHomeAssistantState() == HomeAssistantState.Closed;
+    
+    private readonly Predicate<StateChange> _stateChangedToOpen = stateChange =>
+        !IsInitialOrFaultyState(stateChange.Old?.State)
+        && stateChange.New?.State.ToHomeAssistantState() == HomeAssistantState.Open;
+    
+    private readonly Predicate<StateChange> _stateChangedToLocked = stateChange =>
+        !IsInitialOrFaultyState(stateChange.Old?.State)
+        && stateChange.New?.State.ToHomeAssistantState() == HomeAssistantState.Locked;
+    
+    private readonly Predicate<StateChange> _stateChangedToUnlocked = stateChange =>
+        !IsInitialOrFaultyState(stateChange.Old?.State)
+        && stateChange.New?.State.ToHomeAssistantState() == HomeAssistantState.Unlocked;
+    
+    public DoorSubscriber(
+        IHaContext ha, 
+        House house, 
+        DoorClosedUseCase doorClosedUseCase,
+        DoorOpenedUseCase doorOpenedUseCase,
+        DoorLockedUseCase doorLockedUseCase,
+        DoorUnLockedUseCase doorUnLockedUseCase)
+    {
+        var doorEntities = ha.GetAllEntities()
+            .Where(w => house.Doors.Any(a => a.Id == w.EntityId))
+            .ToList();
+
+        foreach (var doorEntity in doorEntities)
+        {
+            doorEntity.StateChanges()
+                .Where(stateChange => _stateChangedToClose(stateChange))
+                .SubscribeAsync(_ => doorClosedUseCase.HandleAsync(DoorId.Create(doorEntity.EntityId)));
+            
+            doorEntity.StateChanges()
+                .Where(stateChange => _stateChangedToOpen(stateChange))
+                .SubscribeAsync(_ => doorOpenedUseCase.HandleAsync(DoorId.Create(doorEntity.EntityId)));
+            
+            doorEntity.StateChanges()
+                .Where(stateChange => _stateChangedToLocked(stateChange))
+                .SubscribeAsync(_ => doorLockedUseCase.HandleAsync(DoorId.Create(doorEntity.EntityId)));
+            
+            doorEntity.StateChanges()
+                .Where(stateChange => _stateChangedToUnlocked(stateChange))
+                .SubscribeAsync(_ => doorUnLockedUseCase.HandleAsync(DoorId.Create(doorEntity.EntityId)));
+        }
+    }
+}


### PR DESCRIPTION
Introduce a `DoorSubscriber` app to monitor door state changes and trigger appropriate use cases. Implement `DoorOpenedUseCase`, `DoorClosedUseCase`, `DoorLockedUseCase`, and `DoorUnLockedUseCase` to handle respective business logic and update the house state accordingly.